### PR TITLE
Fix build with glibc 2.28

### DIFF
--- a/include/squashfs/unsquashfs.h
+++ b/include/squashfs/unsquashfs.h
@@ -28,6 +28,7 @@
 #    define FALSE 0
 #    include <stdio.h>
 #    include <sys/types.h>
+#    include <sys/sysmacros.h>
 #    include <unistd.h>
 #    include <stdlib.h>
 #    include <sys/stat.h>

--- a/src/cramfs/uncramfs.c
+++ b/src/cramfs/uncramfs.c
@@ -18,6 +18,7 @@
 #include <errno.h>
 //#include <dirent.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <sys/fcntl.h>

--- a/src/jffs2/jffs2extract.cpp
+++ b/src/jffs2/jffs2extract.cpp
@@ -28,6 +28,7 @@
 #include <dirent.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 


### PR DESCRIPTION
> * The macros 'major', 'minor', and 'makedev' are now only available from
>   the header <sys/sysmacros.h>; not from <sys/types.h> or various other
>   headers that happen to include <sys/types.h>.  These macros are rarely
>   used, not part of POSIX nor XSI, and their names frequently collide with
>   user code; see https://sourceware.org/bugzilla/show_bug.cgi?id=19239 for
>   further explanation.

https://lists.gnu.org/archive/html/info-gnu/2018-08/msg00000.html