### PR TITLE
symfile: Fix incorrect format string in symfile_write_idc

### DIFF
--- a/src/symfile.c
+++ b/src/symfile.c
@@ -181,7 +181,7 @@ void symfile_write_idc(const char *fname) {
 			fprintf(outfile, "if(SegName(0x%x)==\".text\") {\n", addr);
 			fprintf(outfile, "   MakeCode(0x%x);\n", addr);
 			fprintf(outfile, "   MakeFunction(0x%x, 0x%x);\n", addr, end);
-			fprintf(outfile, "};\n", addr);
+			fprintf(outfile, "};\n");
 
 	}
 


### PR DESCRIPTION
Warning from gcc:
```bash
src/symfile.c: In function ‘symfile_write_idc’:
src/symfile.c:184:4: warning: too many arguments for format [-Wformat-extra-args]
    fprintf(outfile, "};\n", addr);
    ^
```
Fixes: 7f51874 ("Fixed support for sym files without DWARF section")