### PR TITLE
util: Remove unused variable in isdatetime()

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -385,7 +385,6 @@ int isSTRfile(const char *filename) {
 }
 
 int isdatetime(char *datetime) {
-	time_t rawtime = time(NULL);
 	struct tm time_val;
 
 	// datetime format is YYYYMMDD


### PR DESCRIPTION
Warning reported by gcc 8.2.0:
```bash
src/util.c: In function ‘isdatetime’:
src/util.c:388:9: warning: unused variable ‘rawtime’ [-Wunused-variable]
  time_t rawtime = time(NULL);
         ^~~~~~~
```