### PR TITLE
epk2: Fix incorrect second format string specifier in extractEPK2()

### DIFF
--- a/src/epk2.c
+++ b/src/epk2.c
@@ -267,7 +267,7 @@ void extractEPK2(MFILE *epk, config_opts_t *config_opts) {
 					printf("build=TEST");
 					break;
 				default:
-					printf("build=UNKNOWN %0x%x\n", pak->pakHeader.devMode);
+					printf("build=UNKNOWN 0x%x\n", pak->pakHeader.devMode);
 					break;
 			}
 			printf(")\n");


### PR DESCRIPTION
In the process of refactoring this code, an additional '%' character was added. This changed the format specifier list to take two values, when only one value was always intended to be passed.

Fixes: 2b0f1a5 ("Rewritten EPK2 and EPK3 extractors. Splitted LG keys from MTK keys
                 and reworked key/iv parsing. Also added a few Philips keys")