### PR TITLE
util: Fix C++11 string literal error

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -51,7 +51,7 @@ void print(int verbose, int newline, char *fn, int lineno, const char *fmt, ...)
 #define PRINT(...) print(0, 0 , WHEREARG, __VA_ARGS__)
 #define VERBOSE(N,...) print(N, 0, WHEREARG, __VA_ARGS__)
 #define VERBOSE_NN(N,...) print(N, 0, WHEREARG, __VA_ARGS__)
-#define PERROR_SE(fmt, ...) print(0, 0, WHEREARG, "ERROR: "fmt" (%s)", ## __VA_ARGS__, strerror(errno))
+#define PERROR_SE(fmt, ...) print(0, 0, WHEREARG, "ERROR: " fmt " (%s)", ## __VA_ARGS__, strerror(errno))
 #define PERROR(...) print(0, 1, WHEREARG, "ERROR: " __VA_ARGS__)
 
 #if __WORDSIZE == 64


### PR DESCRIPTION
Insert space between string literal and macro argument, as required in C++11.

This header file can be parsed as C++, as it is imported from C++ file:
`  src/jffs2/jffs2extract.cpp`

C++11 has special syntax for characters immediately following a string literal.
They're interpreted as being a user-defined literal suffix.

Whilst technically only suffixes that start with an underscore can have special
meaning after a string literal in C++11, non-underscore-starting suffixes are
still reserved for use in *future* C++ specifications.

Reported by:
  - gcc   -Wliteral-suffix build warning
  - clang -Wreserved-user-defined-literal build error