### PR TITLE
epk3: Cast unsigned integer type uintptr_t to 'void *'

### DIFF
--- a/src/epk3.c
+++ b/src/epk3.c
@@ -197,9 +197,9 @@ void extractEPK3(MFILE *epk, FILE_TYPE_T epkType, config_opts_t *config_opts){
 	
 	/* Decrypt packageInfo */
 	result = wrap_decryptimage(
-		dataPtr,
+		(void *)dataPtr,
 		epkHeader->packageInfoSize,
-		dataPtr,
+		(void *)dataPtr,
 		config_opts->dest_dir,
 		RAW,
 		NULL


### PR DESCRIPTION
C Standard states this type is "an unsigned integer type with the property that any valid pointer
to void can be converted to this type, then converted back to pointer to void, and the result
will compare equal to the original pointer"

Whilst it says nothing about actual size, it does need to be cast back to pointer to void if
it's being passed to a function parameter 'void *'. This conversion is not automatic.

Compiler warning with clang 7.0.0:
```bash
src/epk3.c:200:3: warning: incompatible integer to pointer conversion passing 'uintptr_t'
      (aka 'unsigned long') to parameter of type 'void *' [-Wint-conversion]
                dataPtr,
                ^~~~~~~
include/epk.h:32:29: note: passing argument to parameter 'src' here
int wrap_decryptimage(void *src, size_t datalen, void *dest, char *confi...
                            ^
src/epk3.c:202:3: warning: incompatible integer to pointer conversion passing 'uintptr_t'
      (aka 'unsigned long') to parameter of type 'void *' [-Wint-conversion]
                dataPtr,
                ^~~~~~~
include/epk.h:32:56: note: passing argument to parameter 'dest' here
int wrap_decryptimage(void *src, size_t datalen, void *dest, char *confi...
                                                       ^
```
Fixes: ed81d33 ("Added support for new epk3 flavour")