### PR TITLE
Fix for first sync search in tsfiles and command line arguments added

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -6,13 +6,16 @@
 #    define CONFIG_H_
 
 #include <stdbool.h>
+#include <inttypes.h>
 
 typedef struct {
 	char *config_dir;
 	char *dest_dir;
 	int enableSignatureChecking;
-	unsigned char video_stream_type;
-	unsigned char audio_stream_type;
+	uint8_t video_stream_type;
+	uint8_t audio_stream_type;
+	uint8_t aes_key[16];
+	bool aes_key_provided;
 } config_opts_t;
 
 extern config_opts_t config_opts;

--- a/include/config.h
+++ b/include/config.h
@@ -11,6 +11,8 @@ typedef struct {
 	char *config_dir;
 	char *dest_dir;
 	int enableSignatureChecking;
+	unsigned char video_stream_type;
+	unsigned char audio_stream_type;
 } config_opts_t;
 
 extern config_opts_t config_opts;

--- a/include/stream/tsfile.h
+++ b/include/stream/tsfile.h
@@ -5,8 +5,9 @@
 #ifndef __TSFILE_H
 #define __TSFILE_H
 #include <stdint.h>
+#include "config.h"
 
-void convertSTR2TS(char *inFilename, int notOverwrite);
-void processPIF(const char *filename, char *dest_file);
+void convertSTR2TS(char *inFilename, int notOverwrite, config_opts_t *config_opts);
+void processPIF(const char *filename, char *dest_file, config_opts_t *config_opts);
 uint32_t str_crc32(const unsigned char *data, int len);
 #endif //__TSFILE_H

--- a/src/stream/tsfile.c
+++ b/src/stream/tsfile.c
@@ -143,16 +143,15 @@ static int setKey(char *keyPath, config_opts_t *config_opts) {
 #define MIN_TS_PACKETS 3
 
 uint8_t *findTsPacket(MFILE *tsFile, long offset){
-	if(offset >= msize(tsFile)){
-		return NULL;
-	}
-
 	uint8_t *head;
 	uint8_t *cur;
 	
 	int syncPackets;
 	
 	do {
+		if(offset >= msize(tsFile)){
+			return NULL;
+		}
 		syncPackets = 0;
 
 		// find initial sync position sequentially
@@ -178,6 +177,7 @@ uint8_t *findTsPacket(MFILE *tsFile, long offset){
 			cur+=TS_PACKET_SIZE,
 			i++);
 
+		++offset;
 	} while(syncPackets<MIN_TS_PACKETS);
 
 	if(syncPackets < MIN_TS_PACKETS){

--- a/src/stream/tsfile.c
+++ b/src/stream/tsfile.c
@@ -65,8 +65,14 @@ static int do_unwrap_func(uint8_t unwrap_key[], uint8_t aes_key[], uint8_t unwra
 	}
 }
 
-static int setKey(char *keyPath) {
+static int setKey(char *keyPath, config_opts_t *config_opts) {
 	int ret = -1;
+
+	if (config_opts->aes_key_provided) {
+		/* AES key already provided by user, no need to retrieve key from dvr file */
+		AES_set_decrypt_key(config_opts->aes_key, 128, &AESkey);
+		return 0;
+	}
 	
 	FILE *keyFile = fopen(keyPath, "r");
 	if (keyFile == NULL) {
@@ -382,7 +388,7 @@ void convertSTR2TS(char *inFilename, int notOverwrite, config_opts_t *config_opt
 	char *keyPath;
 	
 	asprintf(&keyPath, "%s/dvr", baseDir);
-	if (0 != setKey(keyPath)){
+	if (0 != setKey(keyPath, config_opts)){
 		free(keyPath);
 		err_exit("Load DVR Key-file failed for %s/dvr\n", baseDir);
 	}
@@ -417,7 +423,7 @@ void processPIF(const char *filename, char *dest_file, config_opts_t *config_opt
 	char *keyPath;	
 	asprintf(&keyPath, "%s/dvr", baseDir);
 
-	if (0 != setKey(keyPath)){
+	if (0 != setKey(keyPath, config_opts)){
 		free(keyPath);
 		err_exit("Load DVR Key-file failed for %s/dvr\n", baseDir);
 	}


### PR DESCRIPTION
Hello,

here are my changes for the issues I had with some tsfiles. @smx-smx should be able to test/verify this.
Also following command line arguments were added:
 * provide AES key for STR or PIF recordings
 * provide video stream type for STR or PIF recordings
 * provide audio stream type for STR or PIF recordings

Please let me know if things should be changed.

Regards,
wewa00