### PR TITLE
Add nix derivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ src/tools/idb_extract
 src/tools/jffs2extract
 src/tools/lzhs_scanner
 src/tools/lzhsenc
+
+result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,33 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.stdenv.mkDerivation rec {
+  pname = "epk2extract";
+  version = "devel";
+
+  src = ./.;
+
+  buildInputs = [
+    pkgs.cmake
+    pkgs.openssl.dev
+    pkgs.lzo
+    pkgs.zlib
+  ];
+
+  configurePhase = ''
+    cmake .
+  '';
+
+  buildPhase = ''
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cd src
+    cp epk2extract tools/lzhsenc tools/lzhs_scanner tools/idb_extract tools/jffs2extract $out/bin
+
+    chmod -x ../keys/*
+    cp ../keys/*.key ../keys/*.pem $out/bin
+  '';
+}
+


### PR DESCRIPTION
Convenience for NixOS / Nixpkgs users, `nix-build` ran in main project
directory should build this and create a `result/` symlink pointing at a
built package.