### PR TITLE
Fixed build on Mac OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ CMakeFiles
 Makefile
 cmake_install.cmake
 install_manifest.txt
+.DS_Store
 
 ### C ###
 # Object files

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -5,7 +5,7 @@ install_linux(){
 }
 
 install_osx(){
-	brew install zlib lzo openssl@1.1
+	brew install zlib lzo openssl@1.1 gcc@10
 	cd /usr/local/include 
 	ln -s ../opt/openssl/include/openssl .
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,12 @@ find_package(Threads REQUIRED)
 find_package(ZLIB REQUIRED)
 find_library(M_LIB m REQUIRED)
 
-include_directories(${LZO_INCLUDE_DIR})
+if(NOT APPLE)
+  include_directories(${LZO_INCLUDE_DIR})
+endif()
+
+if(APPLE)
+ include_directories(include)
+endif()
 
 add_subdirectory(src)

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,16 @@
 #Copyright 2016 Smx <smxdev4@gmail.com>
 #All right reserved
 
+if [[ "$OSTYPE" =~ "darwin" ]]; then
+	export CC=/usr/local/bin/gcc-10
+	export CXX=/usr/local/bin/g++-10
+	alias gcc='gcc-10'
+	alias cc='gcc-10'
+	alias g++='g++-10'
+	alias c++='c++-10'
+fi
+
+
 normal='tput sgr0'
 lred='printf \033[01;31m'
 lgreen='printf \033[01;32m'
@@ -60,8 +70,13 @@ case "$1" in
 		;;
 esac
 
-cmake $srcdir $CMAKE_FLAGS
-make $MAKE_FLAGS
+if [[ "$OSTYPE" =~ "darwin" ]]; then
+	cmake $srcdir $CMAKE_FLAGS -DCMAKE_C_COMPILER=/usr/local/bin/gcc-10 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++-10
+	make $MAKE_FLAGS --include-dir ./include/
+else
+	cmake $srcdir $CMAKE_FLAGS
+	make $MAKE_FLAGS
+fi
 RESULT=$?
 cd src
 


### PR DESCRIPTION
ATTENTION fixed gcc Version: 10

.gitignore: 		added .DS_Store to make developing on a Mac easier
.travis/install.sh:	added gcc@10 to fullfill the gcc on version 10 requirement
CMakeLists.txt		added differentiation for MacOS where it only includes the headers which are shipped with the repo
build.sh		added differentiation for MacOS to use gcc Version 10 installed via brew, use sepcial Arguments, include the headers which are shipped with the repo