### PR TITLE
Fix output directory names and version display for EPKv1

### DIFF
--- a/include/epk.h
+++ b/include/epk.h
@@ -36,6 +36,7 @@ typedef enum {
 } SIG_TYPE_T;
 
 #define EPK_VERSION_FORMAT "%02" PRIx8 ".%02" PRIx8 ".%02" PRIx8 ".%02" PRIx8
+#define EPKV1_VERSION_FORMAT "%02" PRIx8 ".%02" PRIx8 ".%02" PRIx8
 
 bool isEpkVersionString(const char *str);
 int wrap_verifyimage(void *signature, void *data, size_t signSize, char *config_dir, SIG_TYPE_T sigType);

--- a/include/epk1.h
+++ b/include/epk1.h
@@ -28,6 +28,13 @@ struct epk1BEHeader_t {
 	uint32_t size;
 };
 
+struct epk1BEVersion_t {
+	uint8_t pad;
+	uint8_t major;
+	uint8_t minor1;
+	uint8_t minor2;
+};
+
 struct epk1Header_t {
 	unsigned char epakMagic[4];
 	uint32_t fileSize;

--- a/include/epk1.h
+++ b/include/epk1.h
@@ -54,6 +54,6 @@ struct pakHeader_t {
 };
 
 void extract_epk1_file(const char *epk_file, config_opts_t *config_opts);
-int isFileEPK1(const char *epk_file);
+bool isFileEPK1(const char *epk_file);
 
 #endif /* EPK1_H_ */

--- a/src/epk1.c
+++ b/src/epk1.c
@@ -53,7 +53,7 @@ void constructNewVerString(char *fw_version, struct epk1NewHeader_t *epakHeader)
 
 void extract_epk1_file(const char *epk_file, config_opts_t *config_opts) {
 	int file;
-	if (!(file = open(epk_file, O_RDONLY))) {
+	if ((file = open(epk_file, O_RDONLY)) < 0) {
 		err_exit("\nCan't open file %s\n\n", epk_file);
 	}
 	struct stat statbuf;

--- a/src/epk1.c
+++ b/src/epk1.c
@@ -79,19 +79,15 @@ void extract_epk1_file(const char *epk_file, config_opts_t *config_opts) {
 
 		uint32_t *fwVer = buffer + epakHeader->offset - 4;
 		printf("\nFirmware otaID: %s\n", (char *)(buffer + epakHeader->offset + 8));
-		printf("Firmware version: " EPK_VERSION_FORMAT "\n",
-			(fwVer[0] >> (8 * 0)) & 0xff,
-			(fwVer[0] >> (8 * 1)) & 0xff,
-			(fwVer[0] >> (8 * 2)) & 0xff,
-			(fwVer[0] >> (8 * 3)) & 0xff);
-		printf("PAK count: %d\n", epakHeader->pakCount);
-		printf("PAKs total size: %d\n", epakHeader->fileSize);
-
 		sprintf(verString, EPK_VERSION_FORMAT,
 			(fwVer[0] >> (8 * 0)) & 0xff,
 			(fwVer[0] >> (8 * 1)) & 0xff,
 			(fwVer[0] >> (8 * 2)) & 0xff,
 			(fwVer[0] >> (8 * 3)) & 0xff);
+		printf("Firmware version: %s\n", verString);
+		printf("PAK count: %d\n", epakHeader->pakCount);
+		printf("PAKs total size: %d\n", epakHeader->fileSize);
+
 		asprintf_inplace(&config_opts->dest_dir, "%s/%s", config_opts->dest_dir, verString);
 		createFolder(config_opts->dest_dir);
 

--- a/src/epk1.c
+++ b/src/epk1.c
@@ -15,6 +15,8 @@
 #include "os_byteswap.h"
 #include "util.h"
 
+#define PAKNAME_LEN 4
+
 int isFileEPK1(const char *epk_file) {
 	FILE *file = fopen(epk_file, "rb");
 	if (file == NULL) {
@@ -109,14 +111,29 @@ void extract_epk1_file(const char *epk_file, config_opts_t *config_opts) {
 			struct pakHeader_t *pakHeader = (struct pakHeader_t *)pheader;
 			SWAP(pakHeader->pakSize);
 			pakHeader = (struct pakHeader_t *)(buffer + pakRecord->offset);
-			char pakName[5] = "";
-			sprintf(pakName, "%.*s", 4, pakHeader->pakName);
-			char filename[255] = "";
-			sprintf(filename, "%s/%s.pak", config_opts->dest_dir, pakName);
+
+			char pakName[PAKNAME_LEN + 1] = "";
+			sprintf(pakName, "%.*s", PAKNAME_LEN, pakHeader->pakName);
+
+			char filename[PATH_MAX + 1] = "";
+			int filename_len = snprintf(filename, PATH_MAX + 1, "%s/%s.pak", config_opts->dest_dir, pakName);
+
+			if (filename_len > PATH_MAX) {
+				err_exit("Error in %s: filename too long (%d > %d)\n", __func__, filename_len, PATH_MAX);
+			} else if (filename_len < 0) {
+				err_exit("Error in %s: snprintf() failed (%d)\n", __func__, filename_len);
+			}
+
 			printf("\n#%u/%u saving PAK (name='%s', platform='%s', offset=0x%x, size='%d') to file %s\n", index + 1, epakHeader->pakCount, pakName, pakHeader->platform, pakRecord->offset, pakRecord->size, filename);
-			FILE *outfile = fopen(((const char *)filename), "wb");
+			FILE *outfile = fopen(filename, "wb");
+
+			if (outfile == NULL) {
+				err_exit("Error in %s: failed to open file '%s': %s.\n", __func__, filename, strerror(errno));
+			}
+
 			fwrite(pakHeader->pakName + sizeof(struct pakHeader_t), 1, pakRecord->size - 132, outfile);
 			fclose(outfile);
+
 			handle_file(filename, config_opts);
 			free(pakRecord);
 			free(pheader);
@@ -130,18 +147,34 @@ void extract_epk1_file(const char *epk_file, config_opts_t *config_opts) {
 		constructVerString(verString, epakHeader);
 		asprintf_inplace(&config_opts->dest_dir, "%s/%s", config_opts->dest_dir, verString);
 		createFolder(config_opts->dest_dir);
+
 		for (index = 0; index < epakHeader->pakCount; index++) {
 			struct pakRec_t pakRecord = epakHeader->pakRecs[index];
 			struct pakHeader_t *pakHeader;
 			pakHeader = (struct pakHeader_t *)(buffer + pakRecord.offset);
-			char pakName[5] = "";
-			sprintf(pakName, "%.*s", 4, pakHeader->pakName);
-			char filename[255] = "";
-			sprintf(filename, "%s/%s.pak", config_opts->dest_dir, pakName);
+
+			char pakName[PAKNAME_LEN + 1] = "";
+			sprintf(pakName, "%.*s", PAKNAME_LEN, pakHeader->pakName);
+
+			char filename[PATH_MAX + 1] = "";
+			int filename_len = snprintf(filename, PATH_MAX + 1, "%s/%s.pak", config_opts->dest_dir, pakName);
+
+			if (filename_len > PATH_MAX) {
+				err_exit("Error in %s: filename too long (%d > %d)\n", __func__, filename_len, PATH_MAX);
+			} else if (filename_len < 0) {
+				err_exit("Error in %s: snprintf() failed (%d)\n", __func__, filename_len);
+			}
+
 			printf("\n#%u/%u saving PAK (name='%s', platform='%s', offset=0x%x, size='%d') to file %s\n", index + 1, epakHeader->pakCount, pakName, pakHeader->platform, pakRecord.offset, pakRecord.size, filename);
 			FILE *outfile = fopen(((const char *)filename), "wb");
+
+			if (outfile == NULL) {
+				err_exit("Error in %s: failed to open file '%s': %s.\n", __func__, filename, strerror(errno));
+			}
+
 			fwrite(pakHeader->pakName + sizeof(struct pakHeader_t), 1, pakRecord.size - 132, outfile);
 			fclose(outfile);
+
 			handle_file(filename, config_opts);
 		}
 	} else {					// new EPK1 header
@@ -151,17 +184,33 @@ void extract_epk1_file(const char *epk_file, config_opts_t *config_opts) {
 		constructNewVerString(verString, epakHeader);
 		asprintf_inplace(&config_opts->dest_dir, "%s/%s", config_opts->dest_dir, verString);
 		createFolder(config_opts->dest_dir);
+
 		for (index = 0; index < epakHeader->pakCount; index++) {
 			struct pakRec_t pakRecord = epakHeader->pakRecs[index];
 			struct pakHeader_t *pakHeader = (struct pakHeader_t *)(buffer + pakRecord.offset);
-			char pakName[5] = "";
-			sprintf(pakName, "%.*s", 4, pakHeader->pakName);
-			char filename[255] = "";
-			sprintf(filename, "%s/%s.pak", config_opts->dest_dir, pakName);
+
+			char pakName[PAKNAME_LEN + 1] = "";
+			sprintf(pakName, "%.*s", PAKNAME_LEN, pakHeader->pakName);
+
+			char filename[PATH_MAX + 1] = "";
+			int filename_len = snprintf(filename, PATH_MAX + 1, "%s/%s.pak", config_opts->dest_dir, pakName);
+
+			if (filename_len > PATH_MAX) {
+				err_exit("Error in %s: filename too long (%d > %d)\n", __func__, filename_len, PATH_MAX);
+			} else if (filename_len < 0) {
+				err_exit("Error in %s: snprintf() failed (%d)\n", __func__, filename_len);
+			}
+
 			printf("\n#%u/%u saving PAK (name='%s', platform='%s', offset=0x%x, size='%d') to file %s\n", index + 1, epakHeader->pakCount, pakName, pakHeader->platform, pakRecord.offset, pakRecord.size, filename);
-			FILE *outfile = fopen(((const char *)filename), "wb");
+			FILE *outfile = fopen(filename, "wb");
+
+			if (outfile == NULL) {
+				err_exit("Error in %s: failed to open file '%s': %s.\n", __func__, filename, strerror(errno));
+			}
+
 			fwrite(pakHeader->pakName + sizeof(struct pakHeader_t), 1, pakHeader->pakSize + 4, outfile);
 			fclose(outfile);
+
 			handle_file(filename, config_opts);
 		}
 	}

--- a/src/epk1.c
+++ b/src/epk1.c
@@ -31,24 +31,24 @@ int isFileEPK1(const char *epk_file) {
 
 void printHeaderInfo(struct epk1Header_t *epakHeader) {
 	printf("\nFirmware otaID: %s\n", epakHeader->otaID);
-	printf("Firmware version: " EPK_VERSION_FORMAT "\n", epakHeader->fwVer[3], epakHeader->fwVer[2], epakHeader->fwVer[1], epakHeader->fwVer[0]);
+	printf("Firmware version: " EPKV1_VERSION_FORMAT "\n", epakHeader->fwVer[2], epakHeader->fwVer[1], epakHeader->fwVer[0]);
 	printf("PAK count: %d\n", epakHeader->pakCount);
 	printf("PAKs total size: %d\n", epakHeader->fileSize);
 }
 
 void printNewHeaderInfo(struct epk1NewHeader_t *epakHeader) {
 	printf("\nFirmware otaID: %s\n", epakHeader->otaID);
-	printf("Firmware version: " EPK_VERSION_FORMAT "\n", epakHeader->fwVer[3], epakHeader->fwVer[2], epakHeader->fwVer[1], epakHeader->fwVer[0]);
+	printf("Firmware version: " EPKV1_VERSION_FORMAT "\n", epakHeader->fwVer[2], epakHeader->fwVer[1], epakHeader->fwVer[0]);
 	printf("PAK count: %d\n", epakHeader->pakCount);
 	printf("PAKs total size: %d\n", epakHeader->fileSize);
 }
 
 void constructVerString(char *fw_version, struct epk1Header_t *epakHeader) {
-	sprintf(fw_version, EPK_VERSION_FORMAT "-%s", epakHeader->fwVer[2], epakHeader->fwVer[1], epakHeader->fwVer[0], epakHeader->otaID);
+	sprintf(fw_version, EPKV1_VERSION_FORMAT "-%s", epakHeader->fwVer[2], epakHeader->fwVer[1], epakHeader->fwVer[0], epakHeader->otaID);
 }
 
 void constructNewVerString(char *fw_version, struct epk1NewHeader_t *epakHeader) {
-	sprintf(fw_version, EPK_VERSION_FORMAT "-%s", epakHeader->fwVer[2], epakHeader->fwVer[1], epakHeader->fwVer[0], epakHeader->otaID);
+	sprintf(fw_version, EPKV1_VERSION_FORMAT "-%s", epakHeader->fwVer[2], epakHeader->fwVer[1], epakHeader->fwVer[0], epakHeader->otaID);
 }
 
 void extract_epk1_file(const char *epk_file, config_opts_t *config_opts) {

--- a/src/util.c
+++ b/src/util.c
@@ -517,10 +517,15 @@ void extract_kernel(const char *image_file, const char *destination_file) {
 /**
  * asprintf that allows reuse of strp in variadic arguments (frees strp and replaces it with newly allocated string)
  */
-int asprintf_inplace(char** strp, const char* fmt, ...) {
+int asprintf_inplace(char **strp, const char *fmt, ...) {
     va_list args;
     int result;
-    char* new_strp = NULL;
+    char *new_strp = NULL;
+
+    if ((strp == NULL) || (fmt == NULL)) {
+        err_exit("Error: %s called with NULL argument.\n", __func__);
+    }
+
     va_start(args, fmt);
     result = vasprintf(&new_strp, fmt, args);
     va_end(args);


### PR DESCRIPTION
When I tried to extract `0.1.57.85_ota.epk` ([32LH2000](https://www.lg.com/uk/support/product/lg-32LH2000.AEKJ)), I was getting output directories like `03.75.00.f67130b0-<junk>`. The problem was that the format string being used for the version (`EPK_VERSION_FORMAT`) requires four version number arguments, but only three were given. The last one was printing the address of a string, and the `%s` afterward was printing garbage (the beginning of the header, apparently). Now when I extract it, the directory is `03.75.00-HE_DTV_GP_M_AAAAABAA`.

The incorrect version was also showing up in the header information:
```
Firmware type is EPK1...

Firmware otaID: HE_DTV_GP_M_AAAAABAA
Firmware version: 00.03.75.00
PAK count: 4
PAKs total size: 12362294
```

I don't have any other EPKv1 file of the other types (big endian and "new") to test this on. I also don't know if EPKv1 versions are supposed to only have three components.

I also added some error checking to give users an idea of what went wrong instead of just crashing.