### PR TITLE
Fix crash on command line option(s) without path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 set(CMAKE_CXX_FLAGS_TEST "-Ofast")
 set(CMAKE_C_FLAGS_TEST "-Ofast -funroll-loops -fprefetch-loop-arrays -march=native")
 
-set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD 17)
 set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake-modules/")

--- a/include/common.h
+++ b/include/common.h
@@ -6,8 +6,13 @@
 #define __COMMON_H
 
 /* Branch Prediction Hints */
+#ifdef __GNUC__
 #define LIKELY(x)    __builtin_expect (!!(x), 1)
 #define UNLIKELY(x)  __builtin_expect (!!(x), 0)
+#else
+#define LIKELY(x)	(x)
+#define UNLIKELY(x)	(x)
+#endif
 
 #ifdef __GNUC__
 #define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))

--- a/include/common.h
+++ b/include/common.h
@@ -26,6 +26,12 @@
 #define UNUSED_FUNCTION(x) UNUSED_ ## x
 #endif
 
+#ifdef __GNUC__
+#define FORMAT_PRINTF(x, y) __attribute__((__format__(__printf__, (x), (y))))
+#else
+#define FORMAT_PRINTF(x, y)
+#endif
+
 #define countof(x) (sizeof(x) / sizeof((x)[0]))
 
 #endif

--- a/include/u-boot/partcommon.h
+++ b/include/u-boot/partcommon.h
@@ -40,7 +40,7 @@ typedef enum {
 
 unsigned int dump_partinfo(const char *filename, const char *outfile);
 
-extern char *modelname;
+extern const char *modelname;
 extern part_struct_type part_type;
 
 #endif /* _PART_COMMON_H_ */

--- a/include/util.h
+++ b/include/util.h
@@ -62,16 +62,6 @@ void print(int verbose, int newline, char *fn, int lineno, const char *fmt, ...)
 #define PERROR_SE(fmt, ...) print(0, 0, WHEREARG, "ERROR: " fmt " (%s)", ## __VA_ARGS__, strerror(errno))
 #define PERROR(...) print(0, 1, WHEREARG, "ERROR: " __VA_ARGS__)
 
-#if __WORDSIZE == 64
-#   define LX "%lx"
-#   define LLX LX
-#   define LU "%lu"
-#else
-#   define LX "%x"
-#   define LLX "%llx"
-#   define LU "%u"
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/util.h
+++ b/include/util.h
@@ -20,7 +20,7 @@ extern "C" {
 
 #define member_size(type, member) sizeof(((type *)0)->member)
 #define err_exit(fmt, ...) \
-	exit(err_ret(fmt, ##__VA_ARGS__))
+	exit(err_ret((fmt), ##__VA_ARGS__))
 
 #ifdef __APPLE__
 typedef    unsigned int    uint;
@@ -30,7 +30,7 @@ char *my_basename(const char *path);
 char *my_dirname(const char *path);
 int count_tokens(const char *str, char token, int sz);
 void getch(void);
-void hexdump(void *pAddressIn, long lSize);
+void hexdump(const void *pAddressIn, long lSize);
 void rmrf(const char *path);
 
 /* Print message and return EXIT_FAILURE. (On Cygwin, also waits for keypress.) */
@@ -46,7 +46,7 @@ void unnfsb(const char *filename, const char *extractedFile);
 MFILE *is_gzip(const char *filename);
 int is_jffs2(const char *filename);
 int isSTRfile(const char *filename);
-int isdatetime(char *datetime);
+int isdatetime(const char *datetime);
 int isPartPakfile(const char *filename);
 int is_kernel(const char *image_file);
 void extract_kernel(const char *image_file, const char *destination_file);
@@ -54,7 +54,7 @@ int asprintf_inplace(char **strp, const char *fmt, ...) FORMAT_PRINTF(2, 3);
 
 
 #include <errno.h>
-void print(int verbose, int newline, char *fn, int lineno, const char *fmt, ...) FORMAT_PRINTF(5, 6);
+void print(int verbose, int newline, const char *fn, int lineno, const char *fmt, ...) FORMAT_PRINTF(5, 6);
 #define WHEREARG  __FILE__, __LINE__
 #define PRINT(...) print(0, 0 , WHEREARG, __VA_ARGS__)
 #define VERBOSE(N,...) print(N, 0, WHEREARG, __VA_ARGS__)

--- a/include/util.h
+++ b/include/util.h
@@ -32,6 +32,8 @@ int count_tokens(const char *str, char token, int sz);
 void getch(void);
 void hexdump(void *pAddressIn, long lSize);
 void rmrf(const char *path);
+
+/* Print message and return EXIT_FAILURE. (On Cygwin, also waits for keypress.) */
 int err_ret(const char *format, ...) FORMAT_PRINTF(1, 2);
 
 char *remove_ext(const char *mystr);

--- a/include/util.h
+++ b/include/util.h
@@ -15,6 +15,7 @@ extern "C" {
 #include <stddef.h>
 #include <stdlib.h>
 #include <elf.h>
+#include "common.h"
 #include "mfile.h"
 
 #define member_size(type, member) sizeof(((type *)0)->member)
@@ -31,7 +32,7 @@ int count_tokens(const char *str, char token, int sz);
 void getch(void);
 void hexdump(void *pAddressIn, long lSize);
 void rmrf(const char *path);
-int err_ret(const char *format, ...);
+int err_ret(const char *format, ...) FORMAT_PRINTF(1, 2);
 
 char *remove_ext(const char *mystr);
 char *get_ext(const char *mystr);
@@ -47,11 +48,11 @@ int isdatetime(char *datetime);
 int isPartPakfile(const char *filename);
 int is_kernel(const char *image_file);
 void extract_kernel(const char *image_file, const char *destination_file);
-int asprintf_inplace(char** strp, const char* fmt, ...);
+int asprintf_inplace(char **strp, const char *fmt, ...) FORMAT_PRINTF(2, 3);
 
 
 #include <errno.h>
-void print(int verbose, int newline, char *fn, int lineno, const char *fmt, ...);
+void print(int verbose, int newline, char *fn, int lineno, const char *fmt, ...) FORMAT_PRINTF(5, 6);
 #define WHEREARG  __FILE__, __LINE__
 #define PRINT(...) print(0, 0 , WHEREARG, __VA_ARGS__)
 #define VERBOSE(N,...) print(N, 0, WHEREARG, __VA_ARGS__)

--- a/src/main.c
+++ b/src/main.c
@@ -306,10 +306,12 @@ int main(int argc, char *argv[]) {
 
 	int exit_code = handle_file(input_file, &config_opts);
 
-	if (exit_code == EXIT_FAILURE)
+	if (exit_code == EXIT_FAILURE) {
 		return err_ret("Unsupported input file format: %s\n\n", input_file);
+	}
 
-	return !err_ret("\nExtraction is finished.\n\n");
+	(void) err_ret("\nExtraction is finished.\n\n");
+	return EXIT_SUCCESS;
 }
 
 static int print_usage(void) {
@@ -319,5 +321,5 @@ static int print_usage(void) {
 	printf("  -s : enable signature checking for EPK files\n");
 	printf("  -S : only check signature (implies -s)\n");
 	printf("  -n : no automatic unsquashfs\n\n");
-	return err_ret("");
+	return err_ret(NULL);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,8 @@
 #include <mach-o/dyld.h>
 #endif
 
+static int print_usage(void);
+
 config_opts_t config_opts;
 
 int handle_file(char *file, config_opts_t *config_opts) {
@@ -214,13 +216,7 @@ int handle_file(char *file, config_opts_t *config_opts) {
 int main(int argc, char *argv[]) {
 	printf("\nLG Electronics digital TV firmware package (EPK) extractor version 4.8 (http://openlgtv.org.ru)\n\n");
 	if (argc < 2) {
-		printf("Usage: epk2extract [-options] FILENAME\n\n");
-		printf("Options:\n");
-		printf("  -c : extract to current directory instead of source file directory\n");
-		printf("  -s : enable signature checking for EPK files\n");
-		printf("  -S : only check signature (implies -s)\n");
-		printf("  -n : no automatic unsquashfs\n\n");
-		return err_ret("");
+		return print_usage();
 	}
 
 	char *exe_dir = calloc(1, PATH_MAX);
@@ -279,6 +275,11 @@ int main(int argc, char *argv[]) {
 		}
 	}
 
+	if (optind == argc) {
+		/* no non-option args */
+		return print_usage();
+	}
+
 #ifdef __CYGWIN__
 	char posix[PATH_MAX];
 	cygwin_conv_path(CCP_WIN_A_TO_POSIX, argv[optind], posix, PATH_MAX);
@@ -309,4 +310,14 @@ int main(int argc, char *argv[]) {
 		return err_ret("Unsupported input file format: %s\n\n", input_file);
 
 	return !err_ret("\nExtraction is finished.\n\n");
+}
+
+static int print_usage(void) {
+	printf("Usage: epk2extract [-options] FILENAME\n\n");
+	printf("Options:\n");
+	printf("  -c : extract to current directory instead of source file directory\n");
+	printf("  -s : enable signature checking for EPK files\n");
+	printf("  -S : only check signature (implies -s)\n");
+	printf("  -n : no automatic unsquashfs\n\n");
+	return err_ret("");
 }

--- a/src/util.c
+++ b/src/util.c
@@ -28,7 +28,6 @@
 #include <time.h>
 #include "partinfo.h"
 char *modelname;
-char *mtdname;
 part_struct_type part_type;
 
 //jffs2
@@ -442,10 +441,8 @@ part_struct_type detect_model(struct p2_device_info * pid) {
 		part_type = STRUCT_MTDINFO;	//mtdinfo
 	}
 
-	mtdname = pid->name;
 	modelname = model;
-	/*printf("\nMTD name -> %s\n",mtdname);
-	   printf("%s Detected\n\n", modelname);*/
+	/*printf("%s Detected\n\n", modelname);*/
 
 	return part_type;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -109,7 +109,7 @@ int count_tokens(const char *str, char tok, int sz){
 }
 
 FORMAT_PRINTF(5, 6)
-void print(int verbose, int newline, char *fn, int lineno, const char *fmt, ...) {
+void print(int verbose, int newline, const char *fn, int lineno, const char *fmt, ...) {
 #if 0
 #ifndef DEBUG
 	if (verbose > G_VERBOSE)
@@ -121,7 +121,7 @@ void print(int verbose, int newline, char *fn, int lineno, const char *fmt, ...)
 	char *dir = my_dirname(fn);
 	char *parent = my_dirname(dir);
 
-	char *relative = dir + strlen(parent) + 1;
+	const char *relative = dir + strlen(parent) + 1;
 
 	printf("[%s/%s:%d] ", relative, file, lineno);
 
@@ -140,10 +140,9 @@ void print(int verbose, int newline, char *fn, int lineno, const char *fmt, ...)
 }
 
 void SwapBytes(void *pv, size_t n) {
-	char *p = pv;
-	size_t lo, hi;
-	for (lo = 0, hi = n - 1; hi > lo; lo++, hi--) {
-		char tmp = p[lo];
+	unsigned char *p = pv;
+	for (size_t lo = 0, hi = n - 1; hi > lo; lo++, hi--) {
+		unsigned char tmp = p[lo];
 		p[lo] = p[hi];
 		p[hi] = tmp;
 	}
@@ -159,19 +158,19 @@ void getch(void) {
 	tcsetattr(STDIN_FILENO, TCSANOW, &oldattr);
 }
 
-void hexdump(void *pAddressIn, long lSize) {
+void hexdump(const void *pAddressIn, long lSize) {
 	char szBuf[100];
 	long lIndent = 1;
 	long lOutLen, lIndex, lIndex2, lOutLen2;
 	long lRelPos;
 	struct {
-		char *pData;
+		const char *pData;
 		unsigned long lSize;
 	} buf;
-	unsigned char *pTmp, ucTmp;
-	unsigned char *pAddress = (unsigned char *)pAddressIn;
+	unsigned char ucTmp;
+	const unsigned char *pTmp, *pAddress = pAddressIn;
 
-	buf.pData = (char *)pAddress;
+	buf.pData = (const char *) pAddress;
 	buf.lSize = lSize;
 
 	while (buf.lSize > 0) {
@@ -181,12 +180,12 @@ void hexdump(void *pAddressIn, long lSize) {
 			lOutLen = 16;
 
 		// create a 64-character formatted output line:
-		sprintf(szBuf, " >                                                      %08zX", pTmp - pAddress);
+		sprintf(szBuf, " >                                                      %08tX", pTmp - pAddress);
 		lOutLen2 = lOutLen;
 
 		for (lIndex = 1 + lIndent, lIndex2 = 53 - 15 + lIndent, lRelPos = 0; lOutLen2; lOutLen2--, lIndex += 2, lIndex2++) {
 			ucTmp = *pTmp++;
-			sprintf(szBuf + lIndex, "%02X ", (unsigned short)ucTmp);
+			sprintf(szBuf + lIndex, "%02hhX ", ucTmp);
 			if (!isprint(ucTmp))
 				ucTmp = '.';	// nonprintable char
 			szBuf[lIndex2] = ucTmp;
@@ -200,7 +199,7 @@ void hexdump(void *pAddressIn, long lSize) {
 			lIndex--;
 		szBuf[lIndex] = '<';
 		szBuf[lIndex + 1] = ' ';
-		printf("%s\n", szBuf);
+		puts(szBuf);
 		buf.pData += lOutLen;
 		buf.lSize -= lOutLen;
 	}
@@ -208,7 +207,7 @@ void hexdump(void *pAddressIn, long lSize) {
 
 int unlink_cb(const char *fpath, const struct stat *sb, int typeflag, struct FTW *ftwbuf) {
 	int rv = remove(fpath);
-	if (rv)
+	if (rv != 0)
 		perror(fpath);
 	return rv;
 }
@@ -391,7 +390,7 @@ int isSTRfile(const char *filename) {
 	return result;
 }
 
-int isdatetime(char *datetime) {
+int isdatetime(const char *datetime) {
 	struct tm time_val;
 
 	// datetime format is YYYYMMDD
@@ -458,27 +457,28 @@ int isPartPakfile(const char *filename) {
 
 	struct p2_partmap_info partinfo;
 
-	size_t size = sizeof(struct p2_partmap_info);
-	fread(&partinfo, 1, size, file);
+	fread(&partinfo, 1, sizeof(struct p2_partmap_info), file);
 
-	char *cmagic;
+	char *cmagic = NULL;
 	asprintf(&cmagic, "%x", partinfo.magic);
 
-	int r = isdatetime((char *)cmagic);
+	int r = isdatetime(cmagic);
 	free(cmagic);
 
-	if (r) {
-		printf("Found valid partpak magic 0x%x in %s\n", partinfo.magic, filename);
-	} else {
+	if (r == 0) {
 		return 0;
 	}
 
+	printf("Found valid partpak magic 0x%x in %s\n", partinfo.magic, filename);
+
 	detect_model(&(partinfo.dev));
 	fclose(file);
-	if (part_type == STRUCT_INVALID)
+
+	if (part_type == STRUCT_INVALID) {
 		return 0;
-	else
-		return 1;
+	}
+
+	return 1;
 }
 
 int is_kernel(const char *image_file) {
@@ -525,16 +525,14 @@ void extract_kernel(const char *image_file, const char *destination_file) {
  */
 FORMAT_PRINTF(2, 3)
 int asprintf_inplace(char **strp, const char *fmt, ...) {
-    va_list args;
-    int result;
-    char *new_strp = NULL;
-
     if ((strp == NULL) || (fmt == NULL)) {
         err_exit("Error: %s called with NULL argument.\n", __func__);
     }
 
+	va_list args;
     va_start(args, fmt);
-    result = vasprintf(&new_strp, fmt, args);
+	char *new_strp = NULL;
+    int result = vasprintf(&new_strp, fmt, args);
     va_end(args);
 
     free(*strp);

--- a/src/util.c
+++ b/src/util.c
@@ -108,6 +108,7 @@ int count_tokens(const char *str, char tok, int sz){
 	return no;
 }
 
+FORMAT_PRINTF(5, 6)
 void print(int verbose, int newline, char *fn, int lineno, const char *fmt, ...) {
 #if 0
 #ifndef DEBUG
@@ -218,6 +219,7 @@ void rmrf(const char *path) {
 		nftw(path, unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
 }
 
+FORMAT_PRINTF(1, 2)
 int err_ret(const char *format, ...) {
 	va_list args;
 	va_start(args, format);
@@ -517,6 +519,7 @@ void extract_kernel(const char *image_file, const char *destination_file) {
 /**
  * asprintf that allows reuse of strp in variadic arguments (frees strp and replaces it with newly allocated string)
  */
+FORMAT_PRINTF(2, 3)
 int asprintf_inplace(char **strp, const char *fmt, ...) {
     va_list args;
     int result;

--- a/src/util.c
+++ b/src/util.c
@@ -27,8 +27,8 @@
 //partinfo
 #include <time.h>
 #include "partinfo.h"
-char *modelname;
-part_struct_type part_type;
+const char *modelname = NULL;
+part_struct_type part_type = STRUCT_INVALID;
 
 //jffs2
 #include "jffs2/jffs2.h"
@@ -402,9 +402,9 @@ int isdatetime(const char *datetime) {
 }
 
 /* detect_model - detect model and corresponding part struct */
-part_struct_type detect_model(struct p2_device_info * pid) {
-	char *model;
+static void detect_model(const struct p2_device_info *pid) {
 	part_type = STRUCT_INVALID;
+
 	int ismtk1 = !strcmp("mtk3569-emmc", pid->name);  //match mtk2012
 	int ismtk2 = !strcmp("mtk3598-emmc", pid->name);  //match mtk2013
 	int is1152 = !strcmp("l9_emmc", pid->name);       //match 1152
@@ -415,36 +415,33 @@ part_struct_type detect_model(struct p2_device_info * pid) {
 	int islm14 = !strcmp("mstar-emmc", pid->name);    //match lm14
 
 	if (ismtk1)
-		model = "Mtk 2012 - MTK5369 (Cortex-A9 single-core)";
+		modelname = "Mtk 2012 - MTK5369 (Cortex-A9 single-core)";
 	else if (ismtk2)
-		model = "Mtk 2013 - MTK5398 (Cobra Cortex-A9 dual-core)";
+		modelname = "Mtk 2013 - MTK5398 (Cobra Cortex-A9 dual-core)";
 	else if (is1152)
-		model = "LG1152 (L9)";
+		modelname = "LG1152 (L9)";
 	else if (is1154)
-		model = "LG1154 (H13) / LG1311 (M14)";
+		modelname = "LG1154 (H13) / LG1311 (M14)";
 	else if (isbcm1)
-		model = "BCM 2010 - BCM35XX";
+		modelname = "BCM 2010 - BCM35XX";
 	else if (isbcm2)
-		model = "BCM 2011 - BCM35230";
+		modelname = "BCM 2011 - BCM35230";
 	else if (ismstar)
-		model = "Mstar Saturn6 / Saturn7 / M1 / M1a / LM1";
+		modelname = "Mstar Saturn6 / Saturn7 / M1 / M1a / LM1";
 	else if (islm14)
-		model = "Mstar LM14";
+		modelname = "Mstar LM14";
 	else
-		return part_type;
+		return;
 
 	if (ismtk2 || is1154 || islm14) {
 		part_type = STRUCT_PARTINFOv2;
 	} else if (ismtk1 || is1152) {
-		part_type = STRUCT_PARTINFOv1;	//partinfo v1
+		part_type = STRUCT_PARTINFOv1;
 	} else {
-		part_type = STRUCT_MTDINFO;	//mtdinfo
+		part_type = STRUCT_MTDINFO;
 	}
 
-	modelname = model;
-	/*printf("%s Detected\n\n", modelname);*/
-
-	return part_type;
+	return;
 }
 
 int isPartPakfile(const char *filename) {

--- a/src/util.c
+++ b/src/util.c
@@ -221,14 +221,18 @@ void rmrf(const char *path) {
 
 FORMAT_PRINTF(1, 2)
 int err_ret(const char *format, ...) {
-	va_list args;
-	va_start(args, format);
-	vprintf(format, args);
-	va_end(args);
+	if (format != NULL) {
+		va_list args;
+		va_start(args, format);
+		vprintf(format, args);
+		va_end(args);
+	}
+
 #ifdef __CYGWIN__
 	puts("Press any key to continue...");
 	getch();
 #endif
+
 	return EXIT_FAILURE;
 }
 


### PR DESCRIPTION
For example, `epkextract -s` will cause a crash.

Also includes a bunch of other minor changes adapted from my dev branch.