### PR TITLE
Add zlib1g-dev as a dependency for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To compile on Linux:
 ### Install build dependencies:
 Ubuntu/Debian:
 ```shell
-apt-get install git build-essential cmake liblzo2-dev libssl-dev libc6-dev
+apt-get install git build-essential cmake liblzo2-dev libssl-dev libc6-dev zlib1g-dev
 ```
 Mandriva/Mageia:
 ```shell


### PR DESCRIPTION
Add zlib1g-dev to Ubuntu dependancies as it’s required to build the program. This can help decrease confusion with users.