### PR TITLE
Trivial fix: initialize `argi` in `tsfile.c`

### DIFF
--- a/src/tools/tsfile.c
+++ b/src/tools/tsfile.c
@@ -9,7 +9,7 @@ int main(int argc, char *argv[]){
 	char *tsfile = NULL;
 	int ac = -1, vc = -1;
 
-	int argi; // positional argument index
+	int argi = 0; // positional argument index
 	for(int i=1; i<argc; i++){
 		char *arg = argv[i];
 		if(*arg != '-'){


### PR DESCRIPTION
In `tsfile.c`, the positional argument index (`argi`) was not initialized before use.

Really, `int argi` could be replaced with a `bool`. But I suppose this preserves flexibility in case more positional arguments are added.